### PR TITLE
fix broken image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To improve access to nutritious food in local communities (especially those suff
 
 ## The architecture
 
-![Digital Co-Operative Management System](https://github.com/Call-for-Code/Solution-Starter-Kit-Hunger-2021/blob/master/hunger-starter-kit-architecture.png)
+![Digital Co-Operative Management System](hunger-starter-kit-architecture.png)
 
 1. The user uses their non-smartphone device camera to capture a photo of their product yield for quality testing and analysis.
 1. The user sends a camera image and/or a text message through their non-smartphone device MMS/SMS service.


### PR DESCRIPTION
the arch diagram is not rendering because the link goes to the image location within the github repo, rather than the raw PNG. Instead just refer to it locally since it's in the same repo.